### PR TITLE
Allow webpack to resolve JSON files.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,7 @@ const config = {
         }],
     },
     resolve: {
-        extensions: ['.tsx', '.ts', '.js'],
+        extensions: ['.tsx', '.ts', '.js', '.json'],
     },
     output: {
         filename: 'main.js',


### PR DESCRIPTION
Fixes a build issue with `discord.js-commando` due to it requiring its own `package.json`.